### PR TITLE
Adding `gulpplugin` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "gulp",
         "plugin",
         "gulp plugin",
+        "gulpplugin",
         "file",
         "import",
         "include",


### PR DESCRIPTION
Adding keyword so module gets added to http://gulpjs.com/plugins/
