### PR TITLE
Replaced use of String.replace with simple String.substring usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,17 +29,16 @@ var getExtension = function(p) {
 function getImport(ext, contents, dirname) {
     patterns[ext].lastIndex = 0; // OH lastIndex - how I HATE you.
     var match = patterns[ext].exec(contents);
-    return match ? { matchText: match[0], path: path.join(dirname, match[2])} : undefined;
+    return match ? { matchText: match[0], index: match.index, path: path.join(dirname, match[2])} : undefined;
 }
 
 function processMatch( _import, contents ) {
-    return contents.replace(
-        _import.matchText,
-        processFile(
-            _import.path,
-            String(fs.readFileSync( _import.path ))
-        )
-    );
+    return contents.substring(0,_import.index)+ 
+    processFile(
+        _import.path,
+        String(fs.readFileSync( _import.path ))
+    )+ 
+    contents.substring(_import.index+_import.matchText.length);
 }
 
 function processFile(p, contents) {


### PR DESCRIPTION
This is my fix for an issue I had when using gulp-imports with jQuery. 

The string "$&" appears on line 848 of jquery.js v1.11.1

$& is a special operator for the String.replace function and breaks the intended use.

I have used the index of the match and the length of the matched string to replace it.
